### PR TITLE
Scaffold home page template

### DIFF
--- a/components/post-header/component.php
+++ b/components/post-header/component.php
@@ -20,19 +20,55 @@ Components\register_component_from_config(
 	__DIR__ . '/component',
 	[
 		'children_callback' => function( $children ) {
-
-			$children = [
-				new Component(
+			if ( is_singular() ) {
+				$post_title = new Component(
 					'irving/post-title',
 					[
 						'config' => [
 							'class_name' => 'entry-title',
-							'tag'        => is_singular() ? 'h1' : 'h2',
+							'tag'        => 'h1',
 						],
 					]
-				),
+				);
+			} else {
+				$post_title = new Component(
+					'irving/fragment',
+					[
+						'config'   => [
+							'class_name' => 'entry-title default-max-width',
+							'tag'        => 'h2',
+						],
+						'children' => [
+							[
+								'irving/post-permalink',
+								[
+									'theme'    => 'default',
+									'children' => [
+										[
+											'irving/post-title',
+											[
+												'config' => [
+													'tag' => 'span',
+												],
+											],
+										],
+									],
+								],
+							],
+						],
+					]
+				);
+			}
+
+			$children = [
+				$post_title,
 				new Component(
-					'irving/post-featured-image'
+					'irving/post-featured-image',
+					[
+						'config' => [
+							'class_name' => 'post-thumbnail',
+						],
+					]
 				),
 			];
 

--- a/template-parts/content-none.json
+++ b/template-parts/content-none.json
@@ -1,0 +1,26 @@
+{
+  "name": "irving/container",
+  "config": {
+    "class_name": "no-results not-found",
+    "tag": "section"
+  },
+  "children": [
+    {
+      "name": "irving/container",
+      "config": {
+        "class_name": "page-header alignwide",
+        "tag": "header"
+      },
+      "children": [
+        {
+          "name": "irving/text",
+          "config": {
+            "class_name": "page-title",
+            "content": "Nothing here",
+            "tag": "h1"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/template-parts/content.json
+++ b/template-parts/content.json
@@ -1,0 +1,29 @@
+{
+  "name": "twentytwentyone/post-container",
+  "config": {
+    "class_name": "format-standard hentry"
+  },
+  "children": [
+    {
+      "name": "twentytwentyone/post-header",
+      "config": {
+        "class_name": "entry-header alignwide",
+        "group": "postHeader"
+      }
+    },
+    {
+      "name": "irving/post-excerpt",
+      "config": {
+        "class_name": "entry-content",
+        "group": "postContent"
+      }
+    },
+    {
+      "name": "twentytwentyone/post-footer",
+      "config": {
+        "class_name": "entry-footer default-max-width",
+        "group": "postFooter"
+      }
+    }
+  ]
+}

--- a/templates/index.json
+++ b/templates/index.json
@@ -14,6 +14,19 @@
                 {
                   "name": "template-part/content"
                 }
+              ],
+              "after": [
+                {
+                  "name": "irving/query-pagination"
+                }
+              ],
+              "no_results": [
+                {
+                  "name": "irving/template-part",
+                  "config": {
+                    "name": "content-none"
+                  }
+                }
               ]
             }
           }

--- a/templates/index.json
+++ b/templates/index.json
@@ -2,11 +2,20 @@
   "page": [
     {
       "name": "irving/body-wrapper",
+      "config": {
+        "class_name": "site-main"
+      },
       "children": [
         {
-          "name": "irving/text",
+          "name": "irving/post-list",
           "config": {
-            "content": "templates/index.json"
+            "templates": {
+              "item": [
+                {
+                  "name": "template-part/content"
+                }
+              ]
+            }
           }
         }
       ]


### PR DESCRIPTION
Blocked by #4.

This updates the `index.json` template to use a new template part,
`template-parts/content.json`, which attempts to mimic the content.php
template part from the original theme.

This also updates the twentytwentyone/post-header component so that
titles are wrapped in links when not on singular pages.